### PR TITLE
change ordered processing of blocks

### DIFF
--- a/blockchain_parser/blockchain.py
+++ b/blockchain_parser/blockchain.py
@@ -205,13 +205,16 @@ class Blockchain(object):
         # filter out stale blocks, so we are left only with block indexes
         # that have been confirmed
         # (or are new enough that they haven't yet been confirmed)
-        blockIndexes = list(filter(lambda block: block.hash not in stale_blocks, blockIndexes))
+        blockIndexes = sorted(
+            filter(lambda block: block.hash not in stale_blocks, blockIndexes),
+            key=lambda block: block.height
+        )
 
         if end is None:
             end = len(blockIndexes)
 
         if end < start:
-            blockIndexes = list(reversed(blockIndexes))
+            blockIndexes.reverse()
             start = len(blockIndexes) - start
             end = len(blockIndexes) - end
 


### PR DESCRIPTION
Ordered processing was not working as expected, as it was using the levelDB order which is not based on block height order.